### PR TITLE
fix the "player2 with keyboard" problem

### DIFF
--- a/rpi/gp2xsdk.cpp
+++ b/rpi/gp2xsdk.cpp
@@ -282,8 +282,8 @@ int init_SDL(void)
         if(joy[0])
             logoutput("Found %d joysticks\n",joyCount);
     }
-    else
-        joyCount=1;
+    if(joyCount < 2)
+        joyCount=2;
 
     //sq frig number of players for keyboard
     //joyCount=2;


### PR DESCRIPTION
The lines 259-286 determines how many valid joysticks are plugged to the system and store this number in the joyCount variable. As we can see in the else at line 285, if no joysticks found, joyCount receives 1.

In other words: "If no joysticks found, let's pretend that we have one for player1 (and let's see if fba2x.cfg has some configs to control player1 with a keyboard)."

The problem is that in this scenario (no joysticks), there is no way to control player2, even if the user has a properly configured fba2x.cfg to control player2 with the same keyboard as the player1.
With the change in this PR, pifba will understand that there is a minimum of 2 players.

In other words: "If no joysticks found, let's pretend that we have two joysticks, for player1 and player2 (and let's see if fba2x.cfg has some configs to control player1 and player2 with a keyboard)."